### PR TITLE
Adding back NPM package publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,15 @@ pipeline {
         sh 'yarn build'
         sh 'cp -r dist ./deploy'
         sh 'jupiterone-build'
-        sh 'jupiterone-publish'
+
+        script {
+          if (env.BRANCH_NAME == 'main') {
+            sh 'jupiterone-publish'
+
+            // publish client and types if updated
+            publishNewNpmVersionIfAny('./package.json', './dist')
+          }
+        }
       }
     }
     stage('dev-deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,10 @@ pipeline {
         sh 'yarn build'
         sh 'cp -r dist ./deploy'
         sh 'jupiterone-build'
+        sh 'jupiterone-publish'
 
         script {
           if (env.BRANCH_NAME == 'main') {
-            sh 'jupiterone-publish'
-
             // publish new package version if updated
             publishNewNpmVersionIfAny('./package.json', './dist')
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
           if (env.BRANCH_NAME == 'main') {
             sh 'jupiterone-publish'
 
-            // publish client and types if updated
+            // publish new package version if updated
             publishNewNpmVersionIfAny('./package.json', './dist')
           }
         }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It does **NOT** contain any of your actual data.
 ### How deploying of this package works
 
 When changes are ready to be deployed to the frontend insights page the `package.json` version
-of this repo needs to be manually bumped. This triggers a Github action once merged that publishes a new
+of this repo needs to be manually bumped. This triggers a Jenkins action once merged that publishes a new
 `@jupiterone/insights-dashboard` package version.
 
 Note - Only boards exported from `src/index.ts` will be available in the frontend application.


### PR DESCRIPTION
For some reason we removed the package publishing a while back. Adding this back
