### PR TITLE
Dont fail deploy hook when removal of old S3 items fails

### DIFF
--- a/deploy/hooks.js
+++ b/deploy/hooks.js
@@ -109,15 +109,9 @@ exports.afterDeployTerraform = async (env) => {
 
   const removalWork = objectsToRemove.map((key) => {
     console.log("Removing the following from S3:", key);
-    const promise = s3
-      .deleteObject({ Bucket: S3_BUCKET, Key: key })
-      .promise()
-      .catch((err) => {
-        // Changing a directory/board name will give issues when trying to delete the old directory/board
-        console.error(`Error deleting ${key}! ${err.stack || err.toString()}`);
-      });
+    const promise = s3.deleteObject({ Bucket: S3_BUCKET, Key: key }).promise();
     return promise;
   });
 
-  await pAll(removalWork, { concurrency: 4 });
+  await pAll(removalWork, { concurrency: 4, stopOnError: false });
 };


### PR DESCRIPTION
This deploy hook fails for some environments seemingly when it's trying to remove old keys (we renamed some of the boards): https://jenkins.infra.jupiterone.io/blue/organizations/jenkins/deploy-to-jupiterone-dev-cisco/detail/deploy-to-jupiterone-dev-cisco/14604/pipeline/

Trying this to see if anything changes
