### PR TITLE
No card fix pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "typings": "insights-dashboards.d.ts",
   "scripts": {
     "build": "rimraf dist && rollup -c",
+    "postbuild": "cp yarn.lock package.json ./dist",
     "deploy": "jupiterone-manual-deploy -t jupiterone-dev -a apply",
     "destroy": "jupiterone-manual-deploy -t jupiterone-dev -a destroy",
     "plan": "jupiterone-manual-deploy -t jupiterone-dev -a plan",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/insights-dashboards",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "UNLICENSED",
   "description": "JupiterOne Insights Dashboards",
   "main": "insights-dashboards.js",


### PR DESCRIPTION
The jenkins pipeline is failing to publish the npm package because there is no package.json file in the dist directory.

## QA Checklist

### Insights

- [ ] Update the `package.json` version ex: 1.7.0 -> 1.7.1 or 1.7.0 -> 1.8.0

Note: Once your changes have been merged, the owners of the insights app need to be notified
